### PR TITLE
Test multiple groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ _test
 6.out
 *.sublime-*
 .DS_Store
+# IntelliJ IDEA files
+.idea/*

--- a/google_test.go
+++ b/google_test.go
@@ -94,7 +94,7 @@ func TestGroupOrder(t *testing.T) {
 		t.Fatal(e)
 	} else {
 		for i, a := range agents {
-			g := r.FindGroup(a)
+			g := r.FindGroups(a)[0]
 			gi := getIndexInSlice(r.groups, g) + 1
 			if gi != groups[i] {
 				t.Fatalf("Expected agent %s to have group number %d, got %d.", a, groups[i], gi)


### PR DESCRIPTION
Proposed solution checks all matching groups for matching rule with longest prefix. For conflicting rules - last seen wins. 