### PR TITLE
+Glob-ish matching pattern matching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,15 @@ Or query several paths against same user agent for performance.
     group.Test("/news/article-2012-1")
 
 
+3. Choose pattern matcher
+^^^^^^^^
+`regexp.Regexp` object caches one matching machine per concurrently matched goroutine.
+Every machine allocates 32+KB for every matched expression.
+With broad crawls and robotx.txt caching it becomes a problem.
+
+Alternative matcher that supports only "*" and "$" symbols can be used by setting
+`RobotsPatternMatcherType = GLOB_MATCHER`
+
 Who
 ===
 

--- a/matchers.go
+++ b/matchers.go
@@ -1,0 +1,78 @@
+package robotstxt
+
+import (
+	"regexp"
+	"strings"
+	"github.com/ryanuber/go-glob"
+)
+
+const (
+	REGEXP_MATCHER MatcherType = iota
+	GLOB_MATCHER
+)
+
+type MatcherType int
+
+type MatcherConstructor func(string) (Matcher, error)
+
+type Matcher interface {
+	MatchString(string) bool
+	String() string
+}
+
+type RegexpMatcher struct {
+	re *regexp.Regexp
+}
+
+func NewRegexpMatcher(pattern string) (Matcher, error) {
+	// Escape string before compile.
+	pattern = regexp.QuoteMeta(pattern)
+	pattern = strings.Replace(pattern, `\*`, `.*`, -1)
+	pattern = strings.Replace(pattern, `\$`, `$`, -1)
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return &RegexpMatcher{re}, nil
+}
+
+func (matcher *RegexpMatcher) MatchString(s string) bool {
+	return matcher.re.MatchString(s)
+}
+
+func (matcher *RegexpMatcher) String() string {
+	return matcher.re.String()
+}
+
+type GlobMatcher struct {
+	pattern string
+	originalPattern string
+}
+
+func NewGlobMatcher(pattern string) (Matcher, error) {
+	originalPattern := pattern
+
+	// Glob checks for full string match, so just remove trailing '$'
+	if strings.HasSuffix(pattern, "$") {
+		pattern = strings.TrimRight(pattern, "$")
+
+	// If no explicit end of line, match for any suffix
+	} else if !strings.HasSuffix(pattern, "*") {
+		pattern = pattern + "*"
+	}
+
+	return &GlobMatcher{pattern, originalPattern}, nil
+}
+
+func (matcher *GlobMatcher) MatchString(s string) bool {
+	return glob.Glob(matcher.pattern, s)
+}
+
+func (matcher *GlobMatcher) String() string {
+	// Return regex-style pattern. Used only for tests.
+	pattern := matcher.originalPattern
+	pattern = regexp.QuoteMeta(pattern)
+	pattern = strings.Replace(pattern, `\*`, `.*`, -1)
+	pattern = strings.Replace(pattern, `\$`, `$`, -1)
+	return pattern
+}


### PR DESCRIPTION
@dbalan Can we put it in another branch may be? It's just for test, current matcher type is set to `glob`. It can be reconfigured as module-level variable. All tests pass with both matchers.